### PR TITLE
Fix modules with numbers in them.

### DIFF
--- a/protoc-gen-twirp_ruby/main.go
+++ b/protoc-gen-twirp_ruby/main.go
@@ -242,12 +242,8 @@ func camelCase(s string) string {
 	// case letter. Digits are treated as words.
 	for ; i < len(s); i++ {
 		c := s[i]
-		if c == '_' && i+1 < len(s) && isASCIILower(s[i+1]) {
+		if c == '_' && i+1 < len(s) && (isASCIILower(s[i+1]) || isASCIIDigit(s[i+1])) {
 			continue // Skip the underscore in s.
-		}
-		if isASCIIDigit(c) {
-			t = append(t, c)
-			continue
 		}
 		// Assume we have a letter now - if not, it's a bogus identifier. The next
 		// word is a sequence of characters that must start upper case.
@@ -256,7 +252,7 @@ func camelCase(s string) string {
 		}
 		t = append(t, c) // Guaranteed not lower case.
 		// Accept lower case sequence that follows.
-		for i+1 < len(s) && isASCIILower(s[i+1]) {
+		for i+1 < len(s) && (isASCIILower(s[i+1]) || isASCIIDigit(s[i+1])) {
 			i++
 			t = append(t, s[i])
 		}

--- a/protoc-gen-twirp_ruby/main_test.go
+++ b/protoc-gen-twirp_ruby/main_test.go
@@ -78,6 +78,8 @@ func TestCamelCase(t *testing.T) {
 		{camelCase("FooBar"), "FooBar"},
 		{camelCase("fooBar"), "FooBar"},
 		{camelCase("myLong_miXEDName"), "MyLongMiXEDName"},
+		{camelCase("a2z"), "A2z"},
+		{camelCase("a_2z"), "A2z"},
 	}
 	for _, tt := range tests {
 		if tt.expected != tt.actual {


### PR DESCRIPTION
Protoc ruby will output `A2z` for package name `a2z`.

For reference, [this is what the protobuf ruby code generator does](https://github.com/protocolbuffers/protobuf/blob/d9ccd0c0e6bbda9bf4476088eeb46b02d7dcd327/src/google/protobuf/compiler/ruby/ruby_generator.cc#L252). It seems to only care about underscores for conversion to `CamelCase` from `snake_case`.