### PR TITLE
Generate code with namespaces to other modules

### DIFF
--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    twirp (0.5.2)
+    twirp (1.0.0)
       faraday (~> 0)
       google-protobuf (~> 3.0, >= 3.0.0)
 

--- a/example/hello_world/service.proto
+++ b/example/hello_world/service.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package example.hello_world;
 
+
 service HelloWorld {
     rpc Hello(HelloRequest) returns (HelloResponse);
 }

--- a/protoc-gen-twirp_ruby/main_test.go
+++ b/protoc-gen-twirp_ruby/main_test.go
@@ -35,19 +35,43 @@ func TestFilePathOnlyBaseNoExtension(t *testing.T) {
 	}
 }
 
-func TestPackageToRubyModules(t *testing.T) {
+func TestToRubyType(t *testing.T) {
+	tests := []struct {
+		protoType string
+		modules   []string
+		expected  string
+	}{
+		{"", []string{}, ""},
+		{"", []string{"Foo", "Bar"}, ""},
+		{".foo.my_message", []string{}, "Foo::MyMessage"},
+		{".foo.my_message", []string{"Foo"}, "MyMessage"},
+		{"m.v.p99.hello_world", []string{}, "M::V::P99::HelloWorld"},
+		{"m.v.p99.hello_world", []string{"M", "V"}, "P99::HelloWorld"},
+		{"m.v.p99.hello_world", []string{"M", "V", "P99"}, "HelloWorld"},
+		{"m.v.p99.hello_world", []string{"P99"}, "M::V::P99::HelloWorld"},
+		{"google.protobuf.Empty", []string{"Foo"}, "Google::Protobuf::Empty"},
+	}
+	for _, tt := range tests {
+		actual := toRubyType(tt.protoType, tt.modules)
+		if !reflect.DeepEqual(actual, tt.expected) {
+			t.Errorf("expected %v; actual %v", tt.expected, actual)
+		}
+	}
+}
+
+func TestSplitRubyConstants(t *testing.T) {
 	tests := []struct {
 		pkgName  string
 		expected []string
 	}{
+		{"", []string{}},
 		{"example", []string{"Example"}},
 		{"example.hello_world", []string{"Example", "HelloWorld"}},
 		{"m.v.p", []string{"M", "V", "P"}},
-		{"p99.a2z", []string{"P99", "A2z"}}, // with numbers
-		{"", []string{}},                    // empty, no modules
+		{"p99.a2z", []string{"P99", "A2z"}},
 	}
 	for _, tt := range tests {
-		actual := packageToRubyModules(tt.pkgName)
+		actual := splitRubyConstants(tt.pkgName)
 		if !reflect.DeepEqual(actual, tt.expected) {
 			t.Errorf("expected %v; actual %v", tt.expected, actual)
 		}


### PR DESCRIPTION
Fixes #21

The generated code will include the module namespaces if they are to a different namespace. This allows to reference well known protobug types like `Google::Protobuf::Empty`. For example:

```proto
syntax = "proto3";
import 'google/protobuf/empty.proto';

service TheVoid {
    rpc Nothing(google.protobuf.Empty) returns (google.protobuf.Empty);
}
```

The `.twirp.rb` generated code would be:

```ruby
class TheVoid < Twirp::Service
  service 'TheVoid'
  rpc :Nothing, Google::Protobuf::Empty, Google::Protobuf::Empty, :ruby_method => :nothing
end
```