### PR TITLE
Allow clients to send custom HTTP headers

### DIFF
--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    twirp (0.5.2)
+    twirp (1.0.0)
       faraday (~> 0)
       google-protobuf (~> 3.0, >= 3.0.0)
 

--- a/lib/twirp/client_json.rb
+++ b/lib/twirp/client_json.rb
@@ -30,10 +30,10 @@ module Twirp
 
     # This implementation does not use the defined Protobuf messages to serialize/deserialize data;
     # the request attrs can be anything and the response data is always a plain Hash of attributes.
-    def rpc(rpc_method, attrs={})
+    def rpc(rpc_method, attrs={}, req_opts=nil)
       body = Encoding.encode_json(attrs)
 
-      resp = self.class.make_http_request(@conn, @service_full_name, rpc_method, Encoding::JSON, body)
+      resp = self.class.make_http_request(@conn, @service_full_name, rpc_method, Encoding::JSON, req_opts, body)
       if resp.status != 200
         return ClientResp.new(nil, self.class.error_from_response(resp))
       end


### PR DESCRIPTION
To send custom HTTP headers, add the option `:headers` to the request. For example:

```ruby
# With no headers (default)
client.hello(name: "World")

# With custom request headers
client.hello({name: "World"}, headers: {"X-Auth-Foo": "xfdsa", "My-Header": "foobar"})
```

It is also possible to set the `'Content-Type'` header to send a single JSON request from a Proto client and vice-versa.

```ruby
client.hello(name: "World") # uses application/protobuf by default
client.hello({name: "World"}, headers: {'Content-Type': 'application/json'}) # makes a JSON request
```