### PR TITLE
Append Protobuf parse error in errored service responses

### DIFF
--- a/lib/twirp/service.rb
+++ b/lib/twirp/service.rb
@@ -127,8 +127,12 @@ module Twirp
       input = nil
       begin
         input = Encoding.decode(rack_request.body.read, env[:input_class], content_type)
-      rescue
-        return bad_route_error("Invalid request body for rpc method #{method_name.inspect} with Content-Type=#{content_type}", rack_request)
+      rescue => e
+        error_msg = "Invalid request body for rpc method #{method_name.inspect} with Content-Type=#{content_type}"
+        if e.is_a?(Google::Protobuf::ParseError)
+          error_msg += ": #{e.message.strip}"
+        end
+        return bad_route_error(error_msg, rack_request)
       end
 
       env[:input] = input

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -140,7 +140,8 @@ class ServiceTest < Minitest::Test
     assert_equal 'application/json', headers['Content-Type']
     assert_equal({
       "code" => 'bad_route',
-      "msg"  => 'Invalid request body for rpc method "MakeHat" with Content-Type=application/json',
+      "msg"  => 'Invalid request body for rpc method "MakeHat" with Content-Type=application/json: ' +
+                "Error occurred during parsing: Parse error at 'bad json'",
       "meta" => {"twirp_invalid_route" => "POST /example.Haberdasher/MakeHat"},
     }, JSON.parse(body[0]))
   end
@@ -154,7 +155,8 @@ class ServiceTest < Minitest::Test
     assert_equal 'application/json', headers['Content-Type']
     assert_equal({
       "code" => 'bad_route',
-      "msg"  => 'Invalid request body for rpc method "MakeHat" with Content-Type=application/protobuf',
+      "msg"  => 'Invalid request body for rpc method "MakeHat" with Content-Type=application/protobuf: ' +
+                'Error occurred during parsing: Unexpected EOF inside skipped data',
       "meta" => {"twirp_invalid_route" => "POST /example.Haberdasher/MakeHat"},
     }, JSON.parse(body[0]))
   end


### PR DESCRIPTION
Issue: #26

This yields more diagnostic information when debugging *why* a request
failed.
