### PR TITLE
Add rake to gemspec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Issues and Pull Requests
 
-Features and bugfixes are managed through Github's Issues and Pull Requests. Contributions are wellcome and once approved, they are merged into master.
+Features and bugfixes are managed through Github's Issues and Pull Requests. Contributions are welcome and once approved, they are merged into master.
 
 ## Make a new release (for authors only)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,13 +12,15 @@ GEM
       multipart-post (>= 1.2, < 3)
     google-protobuf (3.5.1.2-universal-darwin)
     multipart-post (2.0.0)
+    rack (2.0.6)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bundler (~> 1)
+  rack
   twirp!
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,14 +12,14 @@ GEM
       multipart-post (>= 1.2, < 3)
     google-protobuf (3.5.1.2-universal-darwin)
     multipart-post (2.0.0)
-    rack (2.0.6)
+    rake (12.3.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bundler (~> 1)
-  rack
+  rake
   twirp!
 
 BUNDLED WITH

--- a/twirp.gemspec
+++ b/twirp.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'google-protobuf', '~> 3.0', '>= 3.0.0'
   spec.add_runtime_dependency 'faraday', '~> 0' # for clients
   spec.add_development_dependency 'bundler', '~> 1'
+  spec.add_development_dependency "rack"
 end

--- a/twirp.gemspec
+++ b/twirp.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'google-protobuf', '~> 3.0', '>= 3.0.0'
   spec.add_runtime_dependency 'faraday', '~> 0' # for clients
   spec.add_development_dependency 'bundler', '~> 1'
-  spec.add_development_dependency "rack"
+  spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
This PR adds `rake` to `gemspec` so users can use `rake` to run the tests.