### PR TITLE
Twirp::Service.error_response(twerr) method

### DIFF
--- a/lib/twirp/error.rb
+++ b/lib/twirp/error.rb
@@ -49,10 +49,10 @@ module Twirp
       ERROR_CODES_TO_HTTP_STATUS.key? code # one of the valid symbols
     end
 
-    # Use this constructors to ensure the errors have valid error codes. Example:
+    # Code constructors to ensure valid error codes. Example:
     #     Twirp::Error.internal("boom")
-    #     Twirp::Error.invalid_argument("foo is mandatory", argument: "foo")
-    #     Twirp::Error.permission_denied("thou shall not pass!", target: "Balrog")
+    #     Twirp::Error.invalid_argument("foo is mandatory", mymeta: "foobar")
+    #     Twirp::Error.permission_denied("Thou shall not pass!", target: "Balrog")
     ERROR_CODES.each do |code|
       define_singleton_method code do |msg, meta=nil|
         new(code, msg, meta)
@@ -62,7 +62,7 @@ module Twirp
     # Wrap another error as a Twirp::Error :internal.
     def self.internal_with(err)
       twerr = internal err.message, cause: err.class.name
-      twerr.cause = err
+      twerr.cause = err # availabe in error hook for inspection, but not in the response
       twerr
     end
 
@@ -80,6 +80,7 @@ module Twirp
       @meta = validate_meta(meta)
     end
 
+    # Key-value representation of the error. Can be directly serialized into JSON.
     def to_h
       h = {
         code: @code,

--- a/lib/twirp/service.rb
+++ b/lib/twirp/service.rb
@@ -24,12 +24,11 @@ module Twirp
 
     class << self
 
-      # Wether to raise exceptions instead of handling them with exception_raised hooks.
+      # Whether to raise exceptions instead of handling them with exception_raised hooks.
       # Useful during tests to easily debug and catch unexpected exceptions.
-      # Default false.
-      attr_accessor :raise_exceptions
+      attr_accessor :raise_exceptions # Default: false
 
-      # Make a Rack response response with a Twirp::Error
+      # Rack response with a Twirp::Error
       def error_response(twerr)
         status = Twirp::ERROR_CODES_TO_HTTP_STATUS[twerr.code]
         headers = {'Content-Type' => Encoding::JSON} # Twirp errors are always JSON, even if the request was protobuf

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -12,6 +12,15 @@ class ServiceTest < Minitest::Test
     Example::Haberdasher.raise_exceptions = true # configure for testing to make debugging easier
   end
 
+  # Class method to make a Rack response with a Twirp errpr
+  def test_service_error_response
+    twerr = Twirp::Error.invalid_argument('foo')
+    resp = Twirp::Service.error_response(twerr)
+    assert_equal 400, resp[0]
+    assert_equal 'application/json', resp[1]['Content-Type']
+    assert_equal '{"code":"invalid_argument","msg":"foo"}', resp[2][0]
+  end
+
   # The rpc DSL should properly build the base Twirp environment for each rpc method.
   def test_rpcs_accessor
     assert_equal 1, Example::Haberdasher.rpcs.size


### PR DESCRIPTION
Allows to easily make valid error responses from outside Twirp:
```ruby
twerr = Twirp::Error.internal("Oops")
[status, headers, body] = Twirp::Service.error_response(twerr)
```

For example, from Rack middleware:

```ruby
class MyMiddleware
  def initialize(app)
    @app = app       
  end                

  def call(env)      
    // do some stuff and decide to return an early Twirp error
    if not_cool(env)
      twerr = Twirp::Error.invalid_argument("not cool", foo: "bar-meta")
      return Twirp::Service.error_response(twerr)
    end

    @app.call(env)   
  end                
end
```