### PR TITLE
Implement Malformed error code

### DIFF
--- a/lib/twirp/error.rb
+++ b/lib/twirp/error.rb
@@ -16,9 +16,10 @@ module Twirp
   # Valid Twirp error codes and their mapping to related HTTP status.
   # This can also be used to check if a code is valid (check if not nil).
   ERROR_CODES_TO_HTTP_STATUS = {
-    canceled:             408, # RequestTimeout
-    invalid_argument:     400, # BadRequest
-    deadline_exceeded:    408, # RequestTimeout
+    canceled:             408, # Request Timeout
+    invalid_argument:     400, # Bad Request
+    malformed:            400, # Bad Request
+    deadline_exceeded:    408, # Request Timeout
     not_found:            404, # Not Found
     bad_route:            404, # Not Found
     already_exists:       409, # Conflict

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -3,9 +3,9 @@ require 'minitest/autorun'
 require_relative '../lib/twirp/error'
 
 class TestErrorCodes < Minitest::Test
-  
+
   def test_error_codes
-    assert_equal 17, Twirp::ERROR_CODES.size
+    assert_equal 18, Twirp::ERROR_CODES.size
 
     # all codes should be symbols
     Twirp::ERROR_CODES.each do |code|
@@ -13,13 +13,13 @@ class TestErrorCodes < Minitest::Test
     end
 
     # check some codes
-    assert_includes Twirp::ERROR_CODES, :internal 
+    assert_includes Twirp::ERROR_CODES, :internal
     assert_includes Twirp::ERROR_CODES, :not_found
     assert_includes Twirp::ERROR_CODES, :invalid_argument
   end
 
   def test_codes_to_http_status
-    assert_equal 17, Twirp::ERROR_CODES_TO_HTTP_STATUS.size
+    assert_equal 18, Twirp::ERROR_CODES_TO_HTTP_STATUS.size
 
     assert_equal 404, Twirp::ERROR_CODES_TO_HTTP_STATUS[:not_found]
     assert_equal 500, Twirp::ERROR_CODES_TO_HTTP_STATUS[:internal]
@@ -52,7 +52,7 @@ class TestTwirpError < Minitest::Test
   end
 
   def test_invalid_constructor # Make sure that only supported codes are implemented (prevent bad metaprogramming)
-    assert_raises NoMethodError do 
+    assert_raises NoMethodError do
       Twirp::invalid_code_error "should fail"
     end
   end
@@ -67,7 +67,7 @@ class TestTwirpError < Minitest::Test
   def test_new_with_valid_metadata
     err = Twirp::Error.new(:internal, "woops", "meta" => "data", "for this" => "error")
     assert_equal "data", err.meta["meta"]
-    assert_equal "error", err.meta["for this"] 
+    assert_equal "error", err.meta["for this"]
     assert_nil err.meta["something else"]
 
     err = Twirp::Error.new(:internal, "woops", meta: "data")
@@ -78,11 +78,11 @@ class TestTwirpError < Minitest::Test
   def test_invalid_metadata
     Twirp::Error.new(:internal, "woops") # ensure the base case doesn't error
 
-    assert_raises ArgumentError do 
+    assert_raises ArgumentError do
       Twirp::Error.new(:internal, "woops", "string key" => :non_string_value)
     end
 
-    assert_raises ArgumentError do 
+    assert_raises ArgumentError do
       Twirp::Error.new(:internal, "woops", "valid key" => "valid val", "bad_one" => 666)
     end
   end
@@ -91,8 +91,8 @@ class TestTwirpError < Minitest::Test
     # returns a hash with attributes
     err = Twirp::Error.new(:internal, "err msg", "key" => "val")
     assert_equal({code: :internal, msg: "err msg", meta: {"key" => "val"}}, err.to_h)
-  
-    # skips meta if not included 
+
+    # skips meta if not included
     err = Twirp::Error.new(:internal, "err msg")
     assert_equal({code: :internal, msg: "err msg"}, err.to_h)
   end

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -145,10 +145,10 @@ class ServiceTest < Minitest::Test
       method: "POST", input: 'bad json', "CONTENT_TYPE" => "application/json"
     status, headers, body = haberdasher_service.call(rack_env)
 
-    assert_equal 404, status
+    assert_equal 400, status
     assert_equal 'application/json', headers['Content-Type']
     assert_equal({
-      "code" => 'bad_route',
+      "code" => 'malformed',
       "msg"  => 'Invalid request body for rpc method "MakeHat" with Content-Type=application/json: ' +
                 "Error occurred during parsing: Parse error at 'bad json'",
       "meta" => {"twirp_invalid_route" => "POST /example.Haberdasher/MakeHat"},
@@ -160,10 +160,10 @@ class ServiceTest < Minitest::Test
       method: "POST", input: 'bad protobuf', "CONTENT_TYPE" => "application/protobuf"
     status, headers, body = haberdasher_service.call(rack_env)
 
-    assert_equal 404, status
+    assert_equal 400, status
     assert_equal 'application/json', headers['Content-Type']
     assert_equal({
-      "code" => 'bad_route',
+      "code" => 'malformed',
       "msg"  => 'Invalid request body for rpc method "MakeHat" with Content-Type=application/protobuf: ' +
                 'Error occurred during parsing: Unexpected EOF inside skipped data',
       "meta" => {"twirp_invalid_route" => "POST /example.Haberdasher/MakeHat"},


### PR DESCRIPTION
Fixes #39 

Service routing logic now returns the new error code `malformed` (400) if the request JSON or Protobuf is invalid. Previously it would return `bad_request` (404), so this is a non-backwards compatible, major version update. But it won't affect existing clients (even in other languages), this would only affect manual requests that were sending invalid JSON or Protobuf.