### PR TITLE
Allow usage of faraday 1.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,19 +2,19 @@ PATH
   remote: .
   specs:
     twirp (1.4.1)
-      faraday (~> 0)
+      faraday (< 2)
       google-protobuf (~> 3.0, >= 3.0.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    faraday (0.17.1)
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    google-protobuf (3.11.2)
-    minitest (5.11.3)
+    google-protobuf (3.11.4)
+    minitest (5.14.0)
     multipart-post (2.1.1)
-    rack (2.0.8)
-    rake (12.3.1)
+    rack (2.2.2)
+    rake (13.0.1)
 
 PLATFORMS
   ruby

--- a/twirp.gemspec
+++ b/twirp.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9'
   spec.add_runtime_dependency 'google-protobuf', '~> 3.0', '>= 3.0.0'
-  spec.add_runtime_dependency 'faraday', '~> 0' # for clients
+  spec.add_runtime_dependency 'faraday', '< 2' # for clients
 
   spec.add_development_dependency 'bundler', '~> 1'
   spec.add_development_dependency 'minitest', '>= 5'


### PR DESCRIPTION
Faraday 1.0.0 was released on Jan 22.
https://github.com/lostisland/faraday/releases/tag/v1.0.0
