### PR TITLE
emit_defaults in json serialization

### DIFF
--- a/lib/twirp/encoding.rb
+++ b/lib/twirp/encoding.rb
@@ -31,7 +31,7 @@ module Twirp
 
       def encode(msg_obj, msg_class, content_type)
         case content_type
-        when JSON  then msg_class.encode_json(msg_obj)
+        when JSON  then msg_class.encode_json(msg_obj, emit_defaults: true)
         when PROTO then msg_class.encode(msg_obj)
         else raise ArgumentError.new("Invalid content_type")
         end

--- a/lib/twirp/error.rb
+++ b/lib/twirp/error.rb
@@ -25,7 +25,7 @@ module Twirp
     already_exists:       409, # Conflict
     permission_denied:    403, # Forbidden
     unauthenticated:      401, # Unauthorized
-    resource_exhausted:   403, # Forbidden
+    resource_exhausted:   429, # Too Many Requests
     failed_precondition:  412, # Precondition Failed
     aborted:              409, # Conflict
     out_of_range:         400, # Bad Request

--- a/lib/twirp/error.rb
+++ b/lib/twirp/error.rb
@@ -25,7 +25,7 @@ module Twirp
     already_exists:       409, # Conflict
     permission_denied:    403, # Forbidden
     unauthenticated:      401, # Unauthorized
-    resource_exhausted:   429, # Too Many Requests
+    resource_exhausted:   403, # Forbidden
     failed_precondition:  412, # Precondition Failed
     aborted:              409, # Conflict
     out_of_range:         400, # Bad Request

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -64,6 +64,15 @@ class ServiceTest < Minitest::Test
     assert_equal({"inches" => 10, "color" => "white"}, JSON.parse(body[0]))
   end
 
+  def test_successful_json_request_emit_defaults
+    rack_env = json_req "/example.Haberdasher/MakeHat", inches: 0 # default int value
+    status, headers, body = haberdasher_service.call(rack_env)
+
+    assert_equal 200, status
+    assert_equal 'application/json', headers['Content-Type']
+    assert_equal({"inches" => 0, "color" => "white"}, JSON.parse(body[0]))
+  end
+
   def test_successful_proto_request
     rack_env = proto_req "/example.Haberdasher/MakeHat", Example::Size.new(inches: 10)
     status, headers, body = haberdasher_service.call(rack_env)


### PR DESCRIPTION
Fixes #56 

Server JSON responses use `emit_defaults: true` to include all fields, even if they have zero-values. This is now the default behavior in the Go implementation (see https://github.com/twitchtv/twirp-ruby/issues/56).