### PR TITLE
Ignore unknown JSON fields when decoding requests.

### DIFF
--- a/lib/twirp/encoding.rb
+++ b/lib/twirp/encoding.rb
@@ -23,7 +23,7 @@ module Twirp
 
       def decode(bytes, msg_class, content_type)
         case content_type
-        when JSON  then msg_class.decode_json(bytes)
+        when JSON  then msg_class.decode_json(bytes, ignore_unknown_fields: true)
         when PROTO then msg_class.decode(bytes)
         else raise ArgumentError.new("Invalid content_type")
         end

--- a/lib/twirp/version.rb
+++ b/lib/twirp/version.rb
@@ -12,5 +12,5 @@
 # permissions and limitations under the License.
 
 module Twirp
-  VERSION = "1.6.0"
+  VERSION = "1.7.0"
 end

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -179,6 +179,15 @@ class ServiceTest < Minitest::Test
     }, JSON.parse(body[0]))
   end
 
+  def test_json_request_ignores_unknown_fields
+    rack_env = json_req "/example.Haberdasher/MakeHat", inches: 10, fake: 3
+    status, headers, body = haberdasher_service.call(rack_env)
+
+    assert_equal 200, status
+    assert_equal 'application/json', headers['Content-Type']
+    assert_equal({"inches" => 10, "color" => "white"}, JSON.parse(body[0]))
+  end
+
   def test_bad_route_triggers_on_error_hooks
     svc = haberdasher_service
 

--- a/twirp.gemspec
+++ b/twirp.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = '>= 1.9'
-  spec.add_runtime_dependency 'google-protobuf', '~> 3.0', '>= 3.0.0'
+  spec.add_runtime_dependency 'google-protobuf', '~> 3.0', '>= 3.7.0'
   spec.add_runtime_dependency 'faraday', '< 2' # for clients
 
   spec.add_development_dependency 'bundler', '~> 1'


### PR DESCRIPTION
In version 3.7 of protobufs the option to ignore unknown JSON fields was
added.  Setting this flag to true makes it so JSON encoded requests can be
mostly backwards compatible just like existing protobuf encoding.

This fixes #59.