### PR TITLE
Add a strict version of JSON encoding

### DIFF
--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -1,18 +1,20 @@
 PATH
   remote: ..
   specs:
-    twirp (1.5.0)
+    twirp (1.7.0)
       faraday (< 2)
-      google-protobuf (~> 3.0, >= 3.0.0)
+      google-protobuf (~> 3.0, >= 3.7.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    faraday (1.0.1)
+    faraday (1.1.0)
       multipart-post (>= 1.2, < 3)
-    google-protobuf (3.11.4)
+      ruby2_keywords
+    google-protobuf (3.13.0)
     multipart-post (2.1.1)
     rack (2.2.3)
+    ruby2_keywords (0.0.2)
 
 PLATFORMS
   ruby
@@ -22,4 +24,4 @@ DEPENDENCIES
   twirp!
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/example/README.md
+++ b/example/README.md
@@ -22,28 +22,13 @@ Now you can send `curl` requests from another terminal window:
 ```sh
 curl --request POST \
   --url http://localhost:8080/twirp/example.hello_world.HelloWorld/Hello \
-  --header 'Content-Type: application/json' \
+  --header 'Content-Type: application/json; strict=true' \
   --data '{"name": "World"}'
 ```
 
 To send requests from Ruby code, run the hello_world client example:
 ```sh
 bundle exec ruby hello_world_client.rb
-```
-
-### Strict JSON Requests
-
-By default JSON requests ignore unknown fields to match the behavior of a
-traditional protocol buffer request.  In certain cases it can be convenient to
-have a request validated and fail if unknown fields are encountered --
-especially when doing testing using curl.  This can be done by specifying a
-strict flag as part of the content type.
-
-```sh
-curl --request POST \
-  --url http://localhost:8080/twirp/example.hello_world.HelloWorld/Hello \
-  --header 'Content-Type: application/json; strict=true' \
-  --data '{"name": "World", "unknown": "field will fail"}'
 ```
 
 ### Run code generation

--- a/example/README.md
+++ b/example/README.md
@@ -31,6 +31,21 @@ To send requests from Ruby code, run the hello_world client example:
 bundle exec ruby hello_world_client.rb
 ```
 
+### Strict JSON Requests
+
+By default JSON requests ignore unknown fields to match the behavior of a
+traditional protocol buffer request.  In certain cases it can be convenient to
+have a request validated and fail if unknown fields are encountered --
+especially when doing testing using curl.  This can be done by specifying a
+strict flag as part of the content type.
+
+```sh
+curl --request POST \
+  --url http://localhost:8080/twirp/example.hello_world.HelloWorld/Hello \
+  --header 'Content-Type: application/json; strict=true' \
+  --data '{"name": "World", "unknown": "field will fail"}'
+```
+
 ### Run code generation
 
 Try to add a new field in `./hello_world/service.proto`, then run the generator code and see if the new field was properly added in the generated files.

--- a/lib/twirp/encoding.rb
+++ b/lib/twirp/encoding.rb
@@ -17,6 +17,10 @@ module Twirp
 
   module Encoding
     JSON = "application/json"
+    # An opt-in content type useful when curling or manually testing a twirp
+    # service.  This will fail if unknown fields are encountered. The return
+    # content type will be application/json.
+    JSON_STRICT = "application/json; strict=true"
     PROTO = "application/protobuf"
 
     class << self
@@ -24,6 +28,7 @@ module Twirp
       def decode(bytes, msg_class, content_type)
         case content_type
         when JSON  then msg_class.decode_json(bytes, ignore_unknown_fields: true)
+        when JSON_STRICT then msg_class.decode_json(bytes)
         when PROTO then msg_class.decode(bytes)
         else raise ArgumentError.new("Invalid content_type")
         end
@@ -32,6 +37,7 @@ module Twirp
       def encode(msg_obj, msg_class, content_type)
         case content_type
         when JSON  then msg_class.encode_json(msg_obj, emit_defaults: true)
+        when JSON_STRICT then msg_class.encode_json(msg_obj, emit_defaults: true)
         when PROTO then msg_class.encode(msg_obj)
         else raise ArgumentError.new("Invalid content_type")
         end
@@ -46,7 +52,7 @@ module Twirp
       end
 
       def valid_content_type?(content_type)
-        content_type == JSON || content_type == PROTO
+        content_type == JSON || content_type == PROTO || content_type == JSON_STRICT
       end
 
       def valid_content_types

--- a/lib/twirp/encoding.rb
+++ b/lib/twirp/encoding.rb
@@ -27,8 +27,8 @@ module Twirp
 
       def decode(bytes, msg_class, content_type)
         case content_type
-        when JSON  then msg_class.decode_json(bytes, ignore_unknown_fields: true)
-        when JSON_STRICT then msg_class.decode_json(bytes)
+        when JSON then msg_class.decode_json(bytes, ignore_unknown_fields: true)
+        when JSON_STRICT then msg_class.decode_json(bytes, ignore_unknown_fields: false)
         when PROTO then msg_class.decode(bytes)
         else raise ArgumentError.new("Invalid content_type")
         end
@@ -36,8 +36,7 @@ module Twirp
 
       def encode(msg_obj, msg_class, content_type)
         case content_type
-        when JSON  then msg_class.encode_json(msg_obj, emit_defaults: true)
-        when JSON_STRICT then msg_class.encode_json(msg_obj, emit_defaults: true)
+        when JSON, JSON_STRICT then msg_class.encode_json(msg_obj, emit_defaults: true)
         when PROTO then msg_class.encode(msg_obj)
         else raise ArgumentError.new("Invalid content_type")
         end

--- a/lib/twirp/encoding.rb
+++ b/lib/twirp/encoding.rb
@@ -36,7 +36,8 @@ module Twirp
 
       def encode(msg_obj, msg_class, content_type)
         case content_type
-        when JSON, JSON_STRICT then msg_class.encode_json(msg_obj, emit_defaults: true)
+        when JSON then msg_class.encode_json(msg_obj, emit_defaults: false)
+        when JSON_STRICT then msg_class.encode_json(msg_obj, emit_defaults: true)
         when PROTO then msg_class.encode(msg_obj)
         else raise ArgumentError.new("Invalid content_type")
         end

--- a/lib/twirp/version.rb
+++ b/lib/twirp/version.rb
@@ -12,5 +12,5 @@
 # permissions and limitations under the License.
 
 module Twirp
-  VERSION = "1.7.0"
+  VERSION = "1.7.1"
 end

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -65,12 +65,21 @@ class ServiceTest < Minitest::Test
   end
 
   def test_successful_json_request_emit_defaults
+    rack_env = json_strict_req "/example.Haberdasher/MakeHat", inches: 0 # default int value
+    status, headers, body = haberdasher_service.call(rack_env)
+
+    assert_equal 200, status
+    assert_equal 'application/json; strict=true', headers['Content-Type']
+    assert_equal({"inches" => 0, "color" => "white"}, JSON.parse(body[0]))
+  end
+  
+  def test_successful_json_request_no_emit_defaults
     rack_env = json_req "/example.Haberdasher/MakeHat", inches: 0 # default int value
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 200, status
     assert_equal 'application/json', headers['Content-Type']
-    assert_equal({"inches" => 0, "color" => "white"}, JSON.parse(body[0]))
+    assert_equal({"color" => "white"}, JSON.parse(body[0]))
   end
 
   def test_successful_proto_request


### PR DESCRIPTION
In some cases when debugging it's nice to have twirp reject JSON
requests that have unknown fields.  This adds a new JSON_STRICT encoding
that will enable this behavior.  It can be opted into by specifying the
strict parameter when specifying the content type.  For curl this looks
like:

```
curl --request POST \
  --url 'http://localhost:8080/twirp/example.hello_world.HelloWorld/Hello' \
  --header 'Content-Type: application/json; strict=true' \
  --data '{"name": "World", "bob": "fail"}'
```