### PR TITLE
Add option to enable strict mode for JSON Client.

### DIFF
--- a/lib/twirp/client_json.rb
+++ b/lib/twirp/client_json.rb
@@ -24,6 +24,7 @@ module Twirp
 
       package = opts[:package].to_s
       service = opts[:service].to_s
+      @strict = opts.fetch( :strict, false )
       raise ArgumentError.new("Missing option :service") if service.empty?
       @service_full_name = package.empty? ? service : "#{package}.#{service}"
     end
@@ -33,7 +34,8 @@ module Twirp
     def rpc(rpc_method, attrs={}, req_opts=nil)
       body = Encoding.encode_json(attrs)
 
-      resp = self.class.make_http_request(@conn, @service_full_name, rpc_method, Encoding::JSON, req_opts, body)
+      encoding = @strict ? Encoding::JSON_STRICT : Encoding::JSON
+      resp = self.class.make_http_request(@conn, @service_full_name, rpc_method, encoding, req_opts, body)
       if resp.status != 200
         return ClientResp.new(nil, self.class.error_from_response(resp))
       end

--- a/lib/twirp/version.rb
+++ b/lib/twirp/version.rb
@@ -12,5 +12,5 @@
 # permissions and limitations under the License.
 
 module Twirp
-  VERSION = "1.7.1"
+  VERSION = "1.7.2"
 end

--- a/test/client_json_test.rb
+++ b/test/client_json_test.rb
@@ -29,6 +29,20 @@ class ClientJSONTest < Minitest::Test
     assert_equal 3, resp.data["blah_resp"]
   end
 
+  def test_client_json_strict_encoding
+    c = Twirp::ClientJSON.new(conn_stub("/my.pkg.Talking/Blah") {|req|
+      assert_equal "application/json; strict=true", req.request_headers['Content-Type']
+      assert_equal '{"blah1":1,"blah2":2}', req.body # body is json
+
+      [200, {}, '{"blah_resp": 3}']
+    }, package: "my.pkg", service: "Talking", strict: true)
+
+    resp = c.rpc :Blah, blah1: 1, blah2: 2
+    assert_nil resp.error
+    refute_nil resp.data
+    assert_equal 3, resp.data["blah_resp"]
+  end
+
   def test_client_json_error
     c = Twirp::ClientJSON.new(conn_stub("/Foo/Foomo") {|req|
       [400, {}, '{"code": "invalid_argument", "msg": "dont like empty"}']


### PR DESCRIPTION
A PR a while back added strict JSON vs non-strict JSON encoding.
This adds a flag to JSON client to enable that strict mode which can be
useful when doing testing.