### PR TITLE
Update google-protobuf to 3.15.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     faraday (1.1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
-    google-protobuf (3.14.0)
+    google-protobuf (3.15.8)
     minitest (5.14.0)
     multipart-post (2.1.1)
     rack (2.2.3)
@@ -22,11 +22,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1)
+  bundler (~> 2)
   minitest (>= 5)
   rack (>= 2.2.3)
   rake
   twirp!
 
 BUNDLED WITH
-   1.17.2
+   2.1.4

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -168,7 +168,7 @@ class ServiceTest < Minitest::Test
     assert_equal({
       "code" => 'malformed',
       "msg"  => 'Invalid request body for rpc method "MakeHat" with Content-Type=application/json: ' +
-                "Error occurred during parsing: Parse error at 'bad json'",
+                "Error occurred during parsing: Error parsing JSON @1:0: Expected: '{'",
       "meta" => {"twirp_invalid_route" => "POST /example.Haberdasher/MakeHat"},
     }, JSON.parse(body[0]))
   end
@@ -183,7 +183,7 @@ class ServiceTest < Minitest::Test
     assert_equal({
       "code" => 'malformed',
       "msg"  => 'Invalid request body for rpc method "MakeHat" with Content-Type=application/protobuf: ' +
-                'Error occurred during parsing: Unexpected EOF inside skipped data',
+                'Error occurred during parsing',
       "meta" => {"twirp_invalid_route" => "POST /example.Haberdasher/MakeHat"},
     }, JSON.parse(body[0]))
   end
@@ -206,7 +206,7 @@ class ServiceTest < Minitest::Test
     assert_equal({
       "code" => 'malformed',
       "msg"  => 'Invalid request body for rpc method "MakeHat" with Content-Type=application/json; strict=true: ' +
-                "Error occurred during parsing: No such field: fake",
+                "Error occurred during parsing: Error parsing JSON @1:20: No such field: fake",
       "meta" => {"twirp_invalid_route" => "POST /example.Haberdasher/MakeHat"},
     }, JSON.parse(body[0]))
   end
@@ -850,4 +850,3 @@ class ServiceTest < Minitest::Test
     end)
   end
 end
-

--- a/twirp.gemspec
+++ b/twirp.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'google-protobuf', '~> 3.0', '>= 3.7.0'
   spec.add_runtime_dependency 'faraday', '< 2' # for clients
 
-  spec.add_development_dependency 'bundler', '~> 1'
+  spec.add_development_dependency 'bundler', '~> 2'
   spec.add_development_dependency 'minitest', '>= 5'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rack', '>= 2.2.3'


### PR DESCRIPTION
google-protobuf diff: https://github.com/protocolbuffers/protobuf/compare/v3.14.0...v3.15.8

This updates google protobuf and updates tests that break with the update.

Only change seems to be to some parsing errors returning slightly different information.

I also update bundler to a more recent version. Since it is a dev only dependency I bundled it with this change.