### PR TITLE
Allow then-able Faraday responses for free client concurrency

### DIFF
--- a/lib/twirp/client_json.rb
+++ b/lib/twirp/client_json.rb
@@ -36,6 +36,15 @@ module Twirp
 
       encoding = @strict ? Encoding::JSON_STRICT : Encoding::JSON
       resp = self.class.make_http_request(@conn, @service_full_name, rpc_method, encoding, req_opts, body)
+
+      rpc_response_thennable(resp) do |resp|
+        rpc_response_to_clientresp(resp)
+      end
+    end
+
+    private
+
+    def rpc_response_to_clientresp(resp)
       if resp.status != 200
         return ClientResp.new(nil, self.class.error_from_response(resp))
       end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -72,6 +72,16 @@ class ClientTest < Minitest::Test
     assert_equal "red", resp.data.color
   end
 
+  def test_proto_thennable
+    c = Example::HaberdasherClient.new(conn_stub_thennable("/example.Haberdasher/MakeHat") {|req|
+      [200, protoheader, proto(Example::Hat, inches: 99, color: "red")]
+    })
+    resp = c.make_hat({})
+    assert_nil resp.error
+    assert_equal 99, resp.data.inches
+    assert_equal "red", resp.data.color
+  end
+
   def test_proto_send_headers
     c = Example::HaberdasherClient.new(conn_stub("/example.Haberdasher/MakeHat") {|req|
       assert_equal "Bar", req.request_headers['My-Foo-Header']
@@ -187,6 +197,17 @@ class ClientTest < Minitest::Test
 
   def test_json_success
     c = Example::HaberdasherClient.new(conn_stub("/example.Haberdasher/MakeHat") {|req|
+      [200, jsonheader, '{"inches": 99, "color": "red"}']
+    }, content_type: "application/json")
+
+    resp = c.make_hat({})
+    assert_nil resp.error
+    assert_equal 99, resp.data.inches
+    assert_equal "red", resp.data.color
+  end
+
+  def test_json_thennable
+    c = Example::HaberdasherClient.new(conn_stub_thennable("/example.Haberdasher/MakeHat") {|req|
       [200, jsonheader, '{"inches": 99, "color": "red"}']
     }, content_type: "application/json")
 
@@ -335,6 +356,29 @@ class ClientTest < Minitest::Test
         end
       end
     end
+  end
+
+  # mock of a promise-like thennable, allowing a call to ".then" to get the real object
+  class Thennable
+    def initialize(obj)
+      @obj = obj
+    end
+
+    def then(&block)
+      block.call(@obj)
+    end
+  end
+
+  module ThennableFaraday
+    def post(*)
+      Thennable.new(super)
+    end
+  end
+
+  def conn_stub_thennable(path, &block)
+    s = conn_stub(path, &block)
+    s.extend(ThennableFaraday)
+    s
   end
 
 end


### PR DESCRIPTION
:wave: I'm working on creating improved support for non-threaded concurrent IO workloads at GitHub, and am creating this PR since we use `twirp-ruby` and it would be great to see it support one small change that would make it easy to enable concurrent requests on a single thread.

This PR adds support for executing the mutation from a Faraday response to ` ClientResp` in a `.then { ... }` block when the object supports `#then`, as is common for promises. This allows extensions of Faraday such as [iopromise-faraday](https://github.com/iopromise-ruby/iopromise-faraday) to return a [Promise](https://github.com/lgierth/promise.rb) of a response rather than an immediate response, and have twirp-ruby work exactly as expected.

This doesn't introduce any dependencies on promise libraries (or any other libraries) or change the behaviour in the normal case.

When a provided Faraday client (with extended behaviour) returns a response supporting `.then { ... }`, it is used. In Ruby 2.6+, all objects support `.then { ... }` but it behaves just like a Promise. In older Ruby (which the `gemspec` indicates support for), this code simply runs the function as before and so should be fully compatible.

The end result is a no-op change for folks using this library right now, but for those adopting [IOPromise](https://github.com/iopromise-ruby/iopromise), this introduces free single-threaded concurrency of RPC calls using this gem - take the `HelloWorld` service from the `example` in this repo being slightly amended to be slow:
```ruby
# Service implementation
class HelloWorldHandler
  def hello(req, env)
    sleep 1
    @count ||= 1
    @count += 1
    puts ">> Hello #{req.name} #{@count} #{Thread.current}"
    {message: "Hello #{req.name} #{@count}"}
  end
end
```

And the client, providing the Twirp client an IOPromise-supporting Faraday that returns a promise (responding to `#then`):
```ruby
puts Time.now

require 'iopromise/faraday'

conn = IOPromise::Faraday.new('http://localhost:8080/twirp')
c = Example::HelloWorld::HelloWorldClient.new(conn)

ps = (0..10).map do
  c.hello(name: "World").then do |resp|
    if resp.error
      puts resp.error
    else
      puts resp.data.message
    end
  end
end

Promise.all(ps).sync

puts Time.now
```

This results in concurrent requests, rather than sequential ones:
```
2021-06-24 06:55:37 +0000
Hello World 37
Hello World 39
Hello World 37
Hello World 38
Hello World 43
Hello World 42
Hello World 41
Hello World 40
Hello World 46
Hello World 45
Hello World 44
2021-06-24 06:55:38 +0000
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.