### PR TITLE
Fix invalid URI client test case

### DIFF
--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -17,7 +17,7 @@ class ClientTest < Minitest::Test
 
   def test_new_with_invalid_url
     assert_raises URI::InvalidURIError do
-      EmptyClient.new("lulz")
+      EmptyClient.new("invalid uri with unescaped spaces")
     end
   end
 


### PR DESCRIPTION
This fixes the invalid URI test case so it correctly returns the expected error

After this change `rake` succeeds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.