### PR TITLE
Don't consider query string as part of method name

### DIFF
--- a/lib/twirp/service.rb
+++ b/lib/twirp/service.rb
@@ -122,7 +122,7 @@ module Twirp
       end
       env[:content_type] = content_type
 
-      path_parts = rack_request.fullpath.split("/")
+      path_parts = rack_request.path.split("/")
       if path_parts.size < 3 || path_parts[-2] != self.full_name
         return route_err(:bad_route, "Invalid route. Expected format: POST {BaseURL}/#{self.full_name}/{Method}", rack_request)
       end
@@ -153,7 +153,7 @@ module Twirp
     end
 
     def route_err(code, msg, req)
-      Twirp::Error.new code, msg, twirp_invalid_route: "#{req.request_method} #{req.fullpath}"
+      Twirp::Error.new code, msg, twirp_invalid_route: "#{req.request_method} #{req.path}"
     end
 
 

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -188,6 +188,15 @@ class ServiceTest < Minitest::Test
     }, JSON.parse(body[0]))
   end
 
+  def test_route_with_query_string
+    rack_env = json_req "/example.Haberdasher/MakeHat?extra=1", inches: 10
+    status, headers, body = haberdasher_service.call(rack_env)
+
+    assert_equal 200, status
+    assert_equal 'application/json', headers['Content-Type']
+    assert_equal({"inches" => 10, "color" => "white"}, JSON.parse(body[0]))
+  end
+
   def test_json_request_ignores_unknown_fields
     rack_env = json_req "/example.Haberdasher/MakeHat", inches: 10, fake: 3
     status, headers, body = haberdasher_service.call(rack_env)


### PR DESCRIPTION
Use the rack method that returns the path without querystring.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.