### PR TITLE
Prepend '::' to Twirp::Service and Twirp::Client to prevent namespace collisions

### DIFF
--- a/example/hello_world/service_twirp.rb
+++ b/example/hello_world/service_twirp.rb
@@ -4,13 +4,13 @@ require_relative 'service_pb.rb'
 
 module Example
   module HelloWorld
-    class HelloWorldService < Twirp::Service
+    class HelloWorldService < ::Twirp::Service
       package 'example.hello_world'
       service 'HelloWorld'
       rpc :Hello, HelloRequest, HelloResponse, :ruby_method => :hello
     end
 
-    class HelloWorldClient < Twirp::Client
+    class HelloWorldClient < ::Twirp::Client
       client_for HelloWorldService
     end
   end

--- a/protoc-gen-twirp_ruby/main.go
+++ b/protoc-gen-twirp_ruby/main.go
@@ -108,7 +108,7 @@ func (g *generator) generateRubyCode(file *descriptor.FileDescriptorProto, pbFil
 	for i, service := range file.Service {
 		svcName := service.GetName()
 
-		print(b, "%sclass %sService < Twirp::Service", indent, camelCase(svcName))
+		print(b, "%sclass %sService < ::Twirp::Service", indent, camelCase(svcName))
 		if pkgName != "" {
 			print(b, "%s  package '%s'", indent, pkgName)
 		}
@@ -123,7 +123,7 @@ func (g *generator) generateRubyCode(file *descriptor.FileDescriptorProto, pbFil
 		print(b, "%send", indent)
 		print(b, "")
 
-		print(b, "%sclass %sClient < Twirp::Client", indent, camelCase(svcName))
+		print(b, "%sclass %sClient < ::Twirp::Client", indent, camelCase(svcName))
 		print(b, "%s  client_for %sService", indent, camelCase(svcName))
 		print(b, "%send", indent)
 		if i < len(file.Service)-1 {


### PR DESCRIPTION
I ran into this issue when I structured my protobufs in such a way that the resulting ruby file ended up like...


```ruby
module CompanyName
  module Twirp
    class MyNewService < Twirp::Service
[...]
```

which causes:

```
uninitialized constant CompanyName::Twirp::Service (NameError)
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.