### PR TITLE
Make response body accessible on ClientResp

### DIFF
--- a/lib/twirp/client.rb
+++ b/lib/twirp/client.rb
@@ -151,7 +151,7 @@ module Twirp
     def rpc(rpc_method, input, req_opts=nil)
       rpcdef = self.class.rpcs[rpc_method.to_s]
       if !rpcdef
-        return ClientResp.new(nil, Twirp::Error.bad_route("rpc not defined on this client"))
+        return ClientResp.new(error: Twirp::Error.bad_route("rpc not defined on this client"))
       end
 
       content_type = (req_opts && req_opts[:headers] && req_opts[:headers]['Content-Type']) || @content_type
@@ -186,15 +186,15 @@ module Twirp
 
     def rpc_response_to_clientresp(resp, content_type, rpcdef)
       if resp.status != 200
-        return ClientResp.new(nil, self.class.error_from_response(resp))
+        return ClientResp.new(error: self.class.error_from_response(resp))
       end
 
       if resp.headers['Content-Type'] != content_type
-        return ClientResp.new(nil, Twirp::Error.internal("Expected response Content-Type #{content_type.inspect} but found #{resp.headers['Content-Type'].inspect}"))
+        return ClientResp.new(error: Twirp::Error.internal("Expected response Content-Type #{content_type.inspect} but found #{resp.headers['Content-Type'].inspect}"))
       end
 
       data = Encoding.decode(resp.body, rpcdef[:output_class], content_type)
-      return ClientResp.new(data, nil)
+      return ClientResp.new(data: data, body: resp.body)
     end
 
   end

--- a/lib/twirp/client_json.rb
+++ b/lib/twirp/client_json.rb
@@ -46,11 +46,11 @@ module Twirp
 
     def rpc_response_to_clientresp(resp)
       if resp.status != 200
-        return ClientResp.new(nil, self.class.error_from_response(resp))
+        return ClientResp.new(error: self.class.error_from_response(resp))
       end
 
       data = Encoding.decode_json(resp.body)
-      return ClientResp.new(data, nil)
+      return ClientResp.new(data: data, body: resp.body)
     end
 
   end

--- a/lib/twirp/client_resp.rb
+++ b/lib/twirp/client_resp.rb
@@ -14,11 +14,13 @@
 module Twirp
   class ClientResp
     attr_accessor :data
+    attr_accessor :body
     attr_accessor :error
 
-    def initialize(data, error)
+    def initialize(data: nil, body: nil, error: nil)
       @data = data
       @error = error
+      @body = body
     end
   end
 end


### PR DESCRIPTION
:wave: This change exposes the Twirp response body via a new `body` attribute on `ClientResp`. The reason for this change is to make it easier for consumers to cache the raw response. The currently exposed `data` attribute is decoded and not cachable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

```ruby
cached_body = Rails.cache.fetch(cache_key) do 
  resp = Twirp::Client.new(faraday_client).get_resource
  resp.body
end

# later...

MsgClass.decode(cached_body)
```

cc @zrdaley for help putting this together