### PR TITLE
Allow Faraday 2.x

### DIFF
--- a/twirp.gemspec
+++ b/twirp.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9'
   spec.add_runtime_dependency 'google-protobuf', '~> 3.0', '>= 3.7.0'
-  spec.add_runtime_dependency 'faraday', '< 2' # for clients
+  spec.add_runtime_dependency 'faraday', '< 3' # for clients
 
   spec.add_development_dependency 'bundler', '~> 2'
   spec.add_development_dependency 'minitest', '>= 5'


### PR DESCRIPTION
Faraday split all of the different adapters out into separate gems and
pulled some common middleware into the main gem. This allows anyone
using the Gem to also use Faraday 2.x.

Quick note that I didn't change Gemfile.lock as I hope that #86 or #87 are merged before this. Tests are all green on Faraday 2.3.

https://github.com/lostisland/faraday/blob/main/CHANGELOG.md

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Closes #84 