### PR TITLE
Ensure `go.mod`/`go.sum` remain tidy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,5 +48,8 @@ jobs:
         with:
           go-version: '1.22'
 
+      - name: Ensure go.mod / go.sum remain tidy
+        run: go mod tidy -diff
+      
       - name: Run Go tests
         run: go test ./protoc-gen-twirp_ruby/... ./internal/gen/typemap/...


### PR DESCRIPTION
`go mod tidy -diff` ensures the `go.mod` and `go.sum` files remain correct. If anything is amiss, it will print the diff along with an error code and then exit.